### PR TITLE
Upgrade cachix/install-nix-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           repository: moergo-sc/zmk
           ref: main
           path: src
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-22.05
       - uses: cachix/cachix-action@v12


### PR DESCRIPTION
Currently the action always fails with an error (see #5 for instance).

This fixes it.

I barely know what cachix is but my google-fu got me here: https://github.com/cachix/cachix-action/issues/144