### PR TITLE
Enable syntax highlighting for .keymap files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.keymap linguist-language=C


### PR DESCRIPTION
Create .gitattributes to treat .keymap fies like .c files for syntax highlighting in GitHub.

An example how *highlighting* looks can be found here: https://github.com/f0i/glove80/blob/main/config/glove80.keymap

vs. the current  template repo *without highlighting*: https://github.com/moergo-sc/glove80-zmk-config/blob/main/config/glove80.keymap