### PR TITLE
Add support for Windows local building

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.keymap linguist-language=C
+
+# Normalise line endings for Dockerfile and shell scripts
+*.sh text eol=lf
+Dockerfile text eol=lf

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,20 @@
+@echo off
+
+setlocal enabledelayedexpansion
+
+set IMAGE=glove80-zmk-config-docker
+
+:: Set branch name from first parameter, default to main if not provided
+if "%~1"=="" (
+	set BRANCH=main
+) else (
+	set BRANCH=%~1
+)
+
+:: Build Docker image
+docker build -t "%IMAGE%" .
+
+:: Run Docker container
+docker run --rm -v "%cd%:/config" -e UID=0 -e GID=0 -e BRANCH="%BRANCH%" "%IMAGE%"
+
+endlocal


### PR DESCRIPTION
I have added scripts and Git attributes to solve several issues preventing local builds on Windows. The repository was designed for building firmware using GitHub Actions, and the Docker emulations provided for building locally do not currently address Windows-specific needs.

### Add batch build script

I’ve created a `.bat` version of [./build.sh](https://github.com/moergo-sc/glove80-zmk-config/blob/7b85d560f24b6c8279e1d09b97bb81a7e9c7b32a/build.sh) to handle natively building and running the Docker image in Windows. Running `./build.sh` in Git Bash fails to mount the root directory to the image as a Docker volume due to use of non-native `pwd`. `./build.bat` is run using native `cmd` and uses `%cd%` instead, which successfully performs the mount.

The batch script is functionally identical to `./build.sh`.

### Force LF endings on line-end-sensitive files

Currently, cloning the repository on Windows with Git’s `core.autocrlf` setting set to `true` will add CRs to the end of every line in every file. This poses a problem with the [./Dockerfile](https://github.com/moergo-sc/glove80-zmk-config/blob/7b85d560f24b6c8279e1d09b97bb81a7e9c7b32a/Dockerfile), which contains bash scripts: these need to have LF endings only. I have modified [./.gitattributes](https://github.com/moergo-sc/glove80-zmk-config/blob/93107285fe2faf2468780f6f62718a3261de3bd8/.gitattributes) to enforce LF line-ends on `./Dockerfile` and bash scripts.

## Building locally on Windows

In Git Bash, CMD or PowerShell:

```bash
git clone git@github.com:moergo-sc/glove80-zmk-config.git
cd glove80-zmk-config
./build.bat
```

This will create a `./glove80.uf2`, which can be flashed to both halves of the keyboard.

Tested on Windows 11 Pro, Docker 28.0.4, Git for Windows 2.49.0.windows.1

Close #23